### PR TITLE
[device_preview_minus] fix not a constant expression

### DIFF
--- a/device_preview_minus/lib/src/frame/keyboard/virtual_keyboard.dart
+++ b/device_preview_minus/lib/src/frame/keyboard/virtual_keyboard.dart
@@ -88,7 +88,7 @@ class _VirtualKeyboard extends StatelessWidget {
 
   static const double minHeight = 214;
   final double height;
-  final double spacing = 12;
+  static const double spacing = 12;
 
   Widget _row(List<Widget> children) {
     return Padding(


### PR DESCRIPTION
Fixes a bug introduced in [[device_preview_minus] Flutter 3.16.0 compatible](https://github.com/rbdog/flutter_note_packages/commit/b2e796e54b1226cec718ebb34ac23a920f28e56d).